### PR TITLE
Bugfix - Dynamic ImageMagick version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,14 @@ RUN wget https://imagemagick.org/download/ImageMagick.tar.gz
 # Install image dependencies
 RUN tar -xzvf libwebp-1.0.1.tar.gz
 RUN tar -xzvf ImageMagick.tar.gz
+# Unpack dependencies
 RUN cd libwebp-1.0.1 \
     && ./configure \
     && make \
     && make install
-RUN cd ImageMagick-7.0.8-14 \
+
+ARG imagemagickVersion
+RUN cd ImageMagick-$imagemagickVersion \
     && ./configure --with-webp \
     && make \
     && make install

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
+echo $(pwd)
+curl https://imagemagick.org/download/ImageMagick.tar.gz -o `pwd`/ImageMagick.tar.gz
+tar -xzvf ImageMagick.tar.gz
+rm ImageMagick.tar.gz
+IMAGEMAGICK_VERSION=$(find `pwd` -name ImageMagick* | sed -n 's/.*\/ImageMagick-\(.*\)/\1/p')
+rm -rf ImageMagick-$IMAGEMAGICK_VERSION
 
-docker build -t 'maisonette-magine:latest' --force-rm .
+echo $IMAGEMAGICK_VERSION
+
+docker build --build-arg imagemagickVersion=$IMAGEMAGICK_VERSION -t 'maisonette-magine:latest' --force-rm .
 
 dockerimage=$(docker images -q -f=reference='maisonette-magine')
 


### PR DESCRIPTION
This commit adds a level of I/O to the build script, in order to get the current downloadable version of ImageMagick. This is then passed into the Dockerfile as an ARG.