### PR TITLE
Bugfix - Error handling for EEXISTS error in Node 8 ( lambda environment )

### DIFF
--- a/lambda/vehicles/local.js
+++ b/lambda/vehicles/local.js
@@ -22,5 +22,6 @@ exports.dir = async (...descriptor) => {
   console.log('imageVehicle.dir: ', descriptor);
   const tmpPath = path.resolve(__dirname, '..', ...descriptor);
   const newDir = await mkdir(tmpPath, { recursive: true }).then(data => tmpPath).catch(err => console.log(err));
-  return newDir;
+  const returnedDir = Object.prototype.hasOwnProperty.call(newDir, 'code') ? tmpPath : newDir;
+  return returnedDir;
 };

--- a/lambda/vehicles/s3.js
+++ b/lambda/vehicles/s3.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk');
+
 const s3 = new AWS.S3({
   signatureVersion: 'v4',
 });
@@ -85,9 +86,9 @@ exports.dir = async (...descriptor) => {
   console.log('imageVehicle.dir: ', ...descriptor);
   const tmpPath = path.resolve('/', ...descriptor);
   if (tmpPath !== '/tmp') {
-    const newDir = await mkdir(tmpPath, { recursive: true }).then(data => tmpPath).catch(err => console.log(err));
-    console.log('newDir', newDir);
-    return newDir;
+    const newDir = await mkdir(tmpPath, { recursive: true }).then(data => tmpPath).catch(err => err);
+    const returnedDir = Object.prototype.hasOwnProperty.call(newDir, 'code') ? tmpPath : newDir;
+    return returnedDir;
   }
   return tmpPath;
 };


### PR DESCRIPTION
When using fs.mkdir in Node, the recursive option will throw an error if the directory already exists. This handles all errors and then returns the original fileCreation, essentially turning this function into a noop.

Closes #27