### PR TITLE
Bugfix - body.params error

### DIFF
--- a/lambda/main.js
+++ b/lambda/main.js
@@ -13,7 +13,7 @@ exports.route = async (event, context, callback) => {
   } else if (event.Records) {
     const fullLocation = event.Records[0].s3.object.key;
     const fileName = fullLocation.split('/').pop();
-    const extension = path.ext(fileName);
+    const extension = path.extname(fileName);
     if (extension === '.json') {
       return callback("Don't work on JSON files");
     }
@@ -26,6 +26,6 @@ exports.route = async (event, context, callback) => {
   const { response, message } = await magick.default(event, gmOpts, environment);
   const { error, ...imageWork } = response;
   await publish.pub(message, imageWork);
-  callback(error, imageWork);
+  return callback(error, imageWork);
   // TO DO: use the return value of imageWork to decide how to use callback(...params).
 };

--- a/lambda/main.js
+++ b/lambda/main.js
@@ -11,6 +11,12 @@ exports.route = async (event, context, callback) => {
     gmOpts = Object.assign({}, gmOpts, { appPath: `${path.resolve(__dirname, 'bin', 'exodus', 'bin', 'magick')}`, imageMagick: true });
     environment = 'api';
   } else if (event.Records) {
+    const fullLocation = event.Records[0].s3.object.key;
+    const fileName = fullLocation.split('/').pop();
+    const extension = path.ext(fileName);
+    if (extension === '.json') {
+      return callback("Don't work on JSON files");
+    }
     gmOpts = Object.assign({}, gmOpts, { appPath: `${path.resolve(__dirname, 'bin', 'exodus', 'bin', 'magick')}`, imageMagick: true });
     environment = 's3';
   } else if (event.key) {


### PR DESCRIPTION
This is most likely the fix for the intermittent errors we have seen in Magine. When the JSON files were getting uploaded to S3, it was triggering the lambda as well, and then trying to perform imagemagick stuff on it, resulting in failures that were only caught when it tried to re-upload the files to the new S3 location. This is a dirty fix, but it allows for the execution to halt ASAP, as opposed to handling it further down the line when it has already loaded in the imagemagick libs and started to allocate heap resources.