### PR TITLE
WIP Feature - Circleci Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,35 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - deploy:
+      - deploy-dev:
           context: magine-dev
+      - deploy-stg:
+          context: magine-stg
+          requires:
+            - deploy-dev
+          filters:
+            branches:
+              only:
+                - master
 
 jobs:
-  deploy: 
+  deploy-dev: 
     machine: true
+    steps:
+      - apply:
+          environment: dev
+  deploy-stg: 
+    machine: true
+    steps:
+      - apply:
+          environment: stg
+
+commands:
+  apply:
+    description: Deploy a Magine lambda function
+    parameters:
+      environment:
+        type: string
     steps:
       - checkout
       - run:
@@ -30,12 +53,12 @@ jobs:
       - run:
           name: Plan
           command: |
-            cd terraform/environments/dev
+            cd terraform/environments/<< parameters.environment >>
             terraform init
             terraform plan
       - run:
           name: Deploy
           command: |
-            cd terraform/environments/dev
+            cd terraform/environments/<< parameters.environment >>
             terraform init
             terraform apply -auto-approve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,18 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install
+          command: |
+            wget https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
+            unzip terraform_0.12.6_linux_amd64.zip
+            rm -rf terraform_0.12.6_linux_amd64.zip
+            sudo mv terraform /usr/local/bin
+            terraform --version
+      - run:
           name: Build
           command: |
             ls
             sh build.sh
-      - run:
-          name: Install Terraform
-          command: |
-            wget https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
-            unzip terraform_0.12.6_linux_amd64.zip
-            sudo mv terraform /usr/local/bin
-            terraform --version
       - run:
           name: Deploy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,5 +26,6 @@ jobs:
       - run:
           name: Deploy
           command: |
+            cd terraform/environments/dev
             terraform init
             terraform plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,8 @@ jobs:
             unzip terraform_0.12.6_linux_amd64.zip
             sudo mv terraform /usr/local/bin
             terraform --version
-            
+      - run:
+          name: Deploy
+          command: |
+            terraform init
+            terraform plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - deploy
+
+jobs:
+  deploy:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: |
+            ls
+            sh build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - deploy
+      - deploy:
+          context: magine-dev
 
 jobs:
   deploy:
@@ -27,5 +28,10 @@ jobs:
           name: Deploy
           command: |
             cd terraform/environments/dev
+
+            export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+            export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+
             terraform init
             terraform plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
           context: magine-dev
 
 jobs:
-  deploy:
+  deploy: 
     machine: true
     steps:
       - checkout
@@ -19,19 +19,23 @@ jobs:
             sudo wget https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
             sudo unzip terraform_0.12.6_linux_amd64.zip
             terraform --version
-      - run:
-          name: Build
-          command: |
-            ls
-            sh build.sh
-      - run:
-          name: Deploy
-          command: |
-            cd terraform/environments/dev
 
             export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
             export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
-
+      - run:
+          name: Build
+          command: |
+            sh build.sh
+      - run:
+          name: Plan
+          command: |
+            cd terraform/environments/dev
+            terraform init
+            terraform plan
+      - run:
+          name: Deploy
+          command: |
+            cd terraform/environments/dev
             terraform init
             terraform apply -auto-approve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,18 @@ workflows:
     jobs:
       - deploy-dev:
           context: magine-dev
+      - approve-stg:
+          type: approval
+          requires:
+            - deploy-dev
+          filters:
+            branches:
+              only:
+                - master
       - deploy-stg:
           context: magine-stg
           requires:
-            - deploy-dev
+            - approve-stg
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,9 @@ jobs:
       - run:
           name: Install
           command: |
-            wget https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
-            unzip terraform_0.12.6_linux_amd64.zip
-            rm -rf terraform_0.12.6_linux_amd64.zip
-            sudo mv terraform /usr/local/bin
+            cd /usr/local/bin
+            sudo wget https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
+            sudo unzip terraform_0.12.6_linux_amd64.zip
             terraform --version
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,4 +34,4 @@ jobs:
             export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
 
             terraform init
-            terraform plan
+            terraform apply -auto-approve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,11 @@ jobs:
           command: |
             ls
             sh build.sh
+      - run:
+          name: Install Terraform
+          command: |
+            wget https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
+            unzip terraform_0.12.6_linux_amd64.zip
+            sudo mv terraform /usr/local/bin
+            terraform --version
+            

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "terraformer-remote-states-use1"
+    key    = "apps/magine/stg.tfstate"
+    region = "us-east-1"
+  }
+}
+
+module "magine" {
+  source = "../../modules/magine"
+
+  description   = "An image service for managing crops and optimizing sizes"
+  region        = "us-east-1"
+  environment   = "stg"
+  assets_bucket = "maisonette-stg"
+  memory_size   = 1280
+  timeout       = 300
+}

--- a/terraform/environments/stg/versions.tf
+++ b/terraform/environments/stg/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
https://circleci.com/workflow-run/e10cf51a-9123-4bc4-9953-b03a1a6548f8

This sets up a deployment pipeline for Magine relying heavily on Terraform. Development is triggered without restrictions and after testing staging can be approved.

The process:
1. Install Terraform
2. Run the build and create the lambda zipfile
3. Apply the changes to AWS
4. Trigger a test run

WIP because I ran into one snag with the staging bucket set up in the us-west-2 region. I need to update the Terraformer project to address this.