### PR TITLE
Bugfix - Staging AWS Region

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 
 workflows:
   version: 2
-  build-deploy:
+  deploy-dev:
     jobs:
       - deploy-dev:
           context: magine-dev
+  deploy-stg:
+    jobs:
       - approve-stg:
           type: approval
-          requires:
-            - deploy-dev
           filters:
             branches:
               only:

--- a/lambda/vehicles/s3.js
+++ b/lambda/vehicles/s3.js
@@ -22,6 +22,7 @@ exports.get = async (event) => {
     Key: fullLocation
   };
   const image = s3Params => new Promise((resolve, reject) => {
+    console.log('Get object:', s3Params);
     s3.getObject(s3Params, (err, data) => {
       if (err) {
         reject(err);
@@ -33,6 +34,7 @@ exports.get = async (event) => {
 
   const imageDecorator = s3Params => new Promise((resolve, reject) => {
     const enhancedParams = Object.assign({}, s3Params, { Key: `${s3Params.Key.split('.')[0]}.json` });
+    console.log('Get object:', enhancedParams);
     s3.getObject(enhancedParams, (err, data) => {
       if (err) {
         reject(err);
@@ -69,6 +71,7 @@ exports.put = async (image, ...imagePaths) => {
     Key: newS3Key
   };
   const newImage = s3Params => new Promise((resolve, reject) => {
+    console.log('Put object:', s3Params)
     s3.upload(s3Params, (err, data) => {
       if (err) {
         reject(err);

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -1,12 +1,12 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 terraform {
   backend "s3" {
-    bucket = "terraformer-remote-states-use1"
+    bucket = "terraformer-remote-states-usw2"
     key    = "apps/magine/stg.tfstate"
-    region = "us-east-1"
+    region = "us-west-2"
   }
 }
 
@@ -14,7 +14,7 @@ module "magine" {
   source = "../../modules/magine"
 
   description   = "An image service for managing crops and optimizing sizes"
-  region        = "us-east-1"
+  region        = "us-west-2"
   environment   = "stg"
   assets_bucket = "maisonette-stg"
   memory_size   = 1280

--- a/terraform/modules/magine/main.tf
+++ b/terraform/modules/magine/main.tf
@@ -1,3 +1,8 @@
+locals {
+  timestamp = "${replace(timestamp(), ":", "-")}"
+}
+
+
 data "aws_s3_bucket" "assets" {
   bucket = "${var.assets_bucket}"
 }
@@ -159,7 +164,7 @@ resource "aws_s3_bucket" "magine" {
 
 resource "aws_s3_bucket_object" "zip" {
   bucket = aws_s3_bucket.magine.id
-  key    = "magine-${timestamp()}.zip"
+  key    = "magine-${local.timestamp}.zip"
   source = "../../../magine.zip"
 }
 
@@ -197,7 +202,7 @@ resource "random_uuid" "uuid" {
 resource "aws_s3_bucket_object" "image" {
   bucket       = aws_s3_bucket.magine.id
   acl          = "private"
-  key          = "media/original/medium/${random_uuid.uuid.result}/sample-${replace(timestamp(), ":", "-")}.jpeg"
+  key          = "media/original/medium/${random_uuid.uuid.result}/sample-${local.timestamp}.jpeg"
   source       = "../../assets/sample.jpeg"
   content_type = "image/jpeg"
 
@@ -213,11 +218,11 @@ resource "aws_s3_bucket_object" "image" {
 resource "aws_s3_bucket_object" "json" {
   bucket       = aws_s3_bucket.magine.id
   acl          = "private"
-  key          = "media/original/medium/${random_uuid.uuid.result}/sample-${replace(timestamp(), ":", "-")}.json"
+  key          = "media/original/medium/${random_uuid.uuid.result}/sample-${local.timestamp}.json"
   content_type = "application/json"
   content      = <<EOF
 {
-  "name": "sample-${replace(timestamp(), ":", "-")}.jpeg",
+  "name": "sample-${local.timestamp}.jpeg",
   "size": "12992",
   "type": "image/jpeg",
   "ref": "page",


### PR DESCRIPTION
We run in us-west-2 for staging environments. This updates magine-stg to run there and splits CircleCi workflows so that staging is separate.

Also here is a fix for inconsistent file names between sample jpeg and json. They will now line up.

On the Strapi side environment variables have been added https://github.com/MaisonetteWorld/terraformer/pull/137