### PR TITLE
Bugfix - No types present in response for image/gif mime types

### DIFF
--- a/lambda/options/gif_conversion.json
+++ b/lambda/options/gif_conversion.json
@@ -1,0 +1,5 @@
+{
+  "gif": {
+    "extension": "gif"
+  }
+}


### PR DESCRIPTION
This is causing an issue where the api changes based on the image type. IT should be immutable.

Closes #55