### PR TITLE
Setup magine-prd environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
           context: magine-qa
           requires:
             - approve-qa
-  deploy-stg:
+  deploy:
     jobs:
       - approve-stg:
           type: approval
@@ -26,10 +26,12 @@ workflows:
           context: magine-stg
           requires:
             - approve-stg
-          filters:
-            branches:
-              only:
-                - master
+      - approve-prd:
+          type: approval
+      - deploy-prd:
+          context: magine-prd
+          requires:
+            - approve-prd
 
 jobs:
   deploy-dev: 
@@ -47,6 +49,11 @@ jobs:
     steps:
       - apply:
           environment: stg
+  deploy-stg: 
+    machine: true
+    steps:
+      - apply:
+          environment: prd
 
 commands:
   apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ workflows:
             - approve-stg
       - approve-prd:
           type: approval
+          requires:
+            - deploy-stg
       - deploy-prd:
           context: magine-prd
           requires:
@@ -49,7 +51,7 @@ jobs:
     steps:
       - apply:
           environment: stg
-  deploy-stg: 
+  deploy-prd: 
     machine: true
     steps:
       - apply:

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,19 +1,19 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 terraform {
   backend "s3" {
-    bucket = "terraformer-remote-states-use1"
+    bucket = "terraformer-remote-states-usw2"
     key    = "apps/magine/dev.tfstate"
-    region = "us-east-1"
+    region = "us-west-2"
   }
 }
 
 module "magine" {
   source = "../../modules/magine"
 
-  region        = "us-east-1"
+  region        = "us-west-2"
   environment   = "dev"
   assets_bucket = "maisonette-dev"
   memory_size   = 1280

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -13,7 +13,6 @@ terraform {
 module "magine" {
   source = "../../modules/magine"
 
-  description   = "An image service for managing crops and optimizing sizes"
   region        = "us-east-1"
   environment   = "dev"
   assets_bucket = "maisonette-dev"

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "terraformer-remote-states-use1"
+    key    = "apps/magine/prd.tfstate"
+    region = "us-east-1"
+  }
+}
+
+module "magine" {
+  source = "../../modules/magine"
+
+  description   = "An image service for managing crops and optimizing sizes"
+  region        = "us-east-1"
+  environment   = "prd"
+  assets_bucket = "maisonette-prd"
+  memory_size   = 1280
+  timeout       = 300
+}

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -13,7 +13,6 @@ terraform {
 module "magine" {
   source = "../../modules/magine"
 
-  description   = "An image service for managing crops and optimizing sizes"
   region        = "us-east-1"
   environment   = "prd"
   assets_bucket = "maisonette-prd"

--- a/terraform/environments/prd/versions.tf
+++ b/terraform/environments/prd/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/environments/qa/main.tf
+++ b/terraform/environments/qa/main.tf
@@ -18,5 +18,4 @@ module "magine" {
   assets_bucket = "maisonette-qa"
   memory_size   = 1280
   timeout       = 300
-  runtime       = "nodejs10.x"
 }

--- a/terraform/environments/qa/main.tf
+++ b/terraform/environments/qa/main.tf
@@ -13,7 +13,6 @@ terraform {
 module "magine" {
   source = "../../modules/magine"
 
-  description   = "An image service for managing crops and optimizing sizes"
   region        = "us-west-2"
   environment   = "qa"
   assets_bucket = "maisonette-qa"

--- a/terraform/environments/qa/main.tf
+++ b/terraform/environments/qa/main.tf
@@ -18,4 +18,5 @@ module "magine" {
   assets_bucket = "maisonette-qa"
   memory_size   = 1280
   timeout       = 300
+  runtime       = "nodejs10.x"
 }

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -13,7 +13,6 @@ terraform {
 module "magine" {
   source = "../../modules/magine"
 
-  description   = "An image service for managing crops and optimizing sizes"
   region        = "us-west-2"
   environment   = "stg"
   assets_bucket = "maisonette-stg"

--- a/terraform/modules/magine/main.tf
+++ b/terraform/modules/magine/main.tf
@@ -124,7 +124,7 @@ resource "aws_lambda_function" "magine" {
   description   = var.description
   role          = aws_iam_role.lambda.arn
   handler       = "lambda/main.route"
-  runtime       = "nodejs8.10"
+  runtime       = var.runtime
   timeout       = var.timeout
   memory_size   = var.memory_size
 

--- a/terraform/modules/magine/main.tf
+++ b/terraform/modules/magine/main.tf
@@ -168,7 +168,7 @@ resource "aws_s3_bucket_object" "zip" {
   source = "../../../magine.zip"
 }
 
-resource "aws_s3_bucket_notification" "notification_1" {
+resource "aws_s3_bucket_notification" "notification" {
   bucket = aws_s3_bucket.magine.id
 
   lambda_function {
@@ -209,7 +209,7 @@ resource "aws_s3_bucket_object" "image" {
   depends_on = [
     aws_lambda_function.magine,
     aws_s3_bucket.magine,
-    aws_s3_bucket_notification.notification_1,
+    aws_s3_bucket_notification.notification,
     aws_s3_bucket_object.zip,
     aws_s3_bucket_object.json
   ]
@@ -235,7 +235,7 @@ EOF
   depends_on = [
     aws_lambda_function.magine,
     aws_s3_bucket.magine,
-    aws_s3_bucket_notification.notification_1,
+    aws_s3_bucket_notification.notification,
     aws_sns_topic.magine,
     aws_s3_bucket_object.zip
   ]

--- a/terraform/modules/magine/variables.tf
+++ b/terraform/modules/magine/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "description" {
   description = "Description of what your Lambda Function does"
-  default     = ""
+  default     = "An image service for managing crops and optimizing sizes"
 }
 
 variable "assets_bucket" {

--- a/terraform/modules/magine/variables.tf
+++ b/terraform/modules/magine/variables.tf
@@ -30,6 +30,6 @@ variable "timeout" {
 }
 
 variable "runtime" {
-  description = "Lambda function runtime, nodejs8.10 or nodejs10.x"
-  default     = "nodejs8.10"
+  description = "Lambda function runtime"
+  default     = "nodejs10.x"
 }

--- a/terraform/modules/magine/variables.tf
+++ b/terraform/modules/magine/variables.tf
@@ -28,3 +28,8 @@ variable "timeout" {
   description = "The amount of time your Lambda Function has to run in seconds"
   default     = 3
 }
+
+variable "runtime" {
+  description = "Lambda function runtime, nodejs8.10 or nodejs10.x"
+  default     = "nodejs8.10"
+}


### PR DESCRIPTION
This sets up Terraform config and a CircleCi deploy job for the production environment.

https://circleci.com/workflow-run/4640f671-805c-4092-a405-198e0f99f99a

Other changes:

- Deploy magine-dev to us-west-2, the build is currently failing due to a delay in recreating buckets after destroying them
- Variable runtime in anticipation of Node10 upgrade
- General style improvements