### PR TITLE
Bugfix - Serve most optimized images first

### DIFF
--- a/lambda/options/jpeg_conversion.json
+++ b/lambda/options/jpeg_conversion.json
@@ -1,11 +1,11 @@
 {
-  "jpeg": {
-    "extension": "jpg"
+  "webp": {
+    "extension": "webp"
   },
   "jpeg2000": {
     "extension": "jp2"
   },
-  "webp": {
-    "extension": "webp"
+  "jpeg": {
+    "extension": "jpg"
   }
 }

--- a/lambda/options/jpg_conversion.json
+++ b/lambda/options/jpg_conversion.json
@@ -1,11 +1,11 @@
 {
-  "jpg": {
-    "extension": "jpg"
+  "webp": {
+    "extension": "webp"
   },
   "jpeg2000": {
     "extension": "jp2"
   },
-  "webp": {
-    "extension": "webp"
+  "jpeg": {
+    "extension": "jpg"
   }
 }

--- a/lambda/options/png_conversion.json
+++ b/lambda/options/png_conversion.json
@@ -1,8 +1,8 @@
 {
-  "png": {
-    "extension": "png"
-  },
   "webp": {
     "extension": "webp"
+  },
+  "png": {
+    "extension": "png"
   }
 }


### PR DESCRIPTION
This changes the order of the conversion params so that the msot optimized and future facing ones are first in the list, and hopefully, first in the `types` array returned by this lambda. This effects both the frontend and the cms, as they are relying on the types array. There shouldn't be any changes necessary for the intended effect in those repos though.

Related to https://github.com/MaisonetteWorld/maisonette-frontend/issues/968