### PR TITLE
[TEC-2619] Save image dimensions in image object

### DIFF
--- a/lambda/magick.js
+++ b/lambda/magick.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const util = require('util');
+const sizeOf = require('image-size');
 
 const writeFile = util.promisify(fs.writeFile);
 const resize = require('./resize').default;
@@ -35,11 +36,17 @@ exports.default = async (event, gmOptions, env) => {
   const resizeImages = await resize(rules, imageVehicle, storageKey, uuid, imageName, tempOriginal, appPath);
   const { error: newErr, converted } = await format(resizeImages);
   const types = await converted;
+  const dimensions = sizeOf(tempOriginal);
   const response = {
     error: newErr,
     types,
     imageName,
-    uri: `${storageKey}/${uuid}/`
+    uri: `${storageKey}/${uuid}/`,
+    dimensions: {
+      originalHeight: dimensions.height,
+      originalWidth: dimensions.width,
+      aspectRatio: parseFloat((dimensions.width / dimensions.height).toFixed(2))
+    }
   };
   // response should look like this:
   /*

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "ajv": "6.10.0",
-    "aws-sdk": "2.229.1"
+    "aws-sdk": "2.229.1",
+    "image-size": "^0.9.3"
   },
   "devDependencies": {
     "eslint": "^5.9.0",


### PR DESCRIPTION
# ISSUE NUMBER

TEC-2619

## ISSUE DESCRIPTION

On the frontend we want to know image dimensions before having to fetch the image, in order to reserve the required space and avoid page jumps.

Now, every-time an image is uploaded, its dimensions are saved as well.

Example:
<img width="892" alt="Screen Shot 2021-01-13 at 13 34 48" src="https://user-images.githubusercontent.com/31952489/104453051-25140a80-55a4-11eb-94a4-51b1852dc837.png">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on https://cms.qa.env.maisonette.com/

Simply upload an image, wait for the resize process to finish and check the image object.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings