### PR TITLE
[TEC-2795] 403 on images (2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN rm openjpeg-*.tar.gz
 RUN rm ImageMagick-*.tar.gz
 
 # pip installation
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py
 
 # Exodus installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2.0.20200722.0
 
 MAINTAINER Jonathan Kempf <kempfjj@protonmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,10 @@ RUN yum clean all
 
 # Download image dependencies
 RUN wget https://www.imagemagick.org/download/delegates/openjpeg-2.3.0.tar.gz
-RUN wget https://www.imagemagick.org/download/ImageMagick.tar.gz
+RUN wget https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-7.0.10-35.tar.gz
 
 RUN tar -xzvf openjpeg-*.tar.gz
-RUN tar -xzvf ImageMagick.tar.gz
+RUN tar -xzvf ImageMagick-7.0.10-35.tar.gz
 
 RUN cd openjpeg-* \
     && mkdir build \
@@ -58,7 +58,7 @@ RUN /usr/local/bin/magick -list format | grep -i "^[[:space:]]*webp"
 
 # Remove tar files
 RUN rm openjpeg-*.tar.gz
-RUN rm ImageMagick.tar.gz
+RUN rm ImageMagick-*.tar.gz
 
 # pip installation
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py


### PR DESCRIPTION
Issues that were causing image upload to break:
- latest imagemagick version not compiling correctly
- pip not supporting python 2.7 by default anymore