### PR TITLE
[TEC-2567] Gif optimization

### DIFF
--- a/lambda/magick.js
+++ b/lambda/magick.js
@@ -31,9 +31,24 @@ exports.default = async (event, gmOptions, env) => {
   // get data options for images based on path
   const rules = imageOptions.paths(processingRule);
   const { appPath = 'magick' } = gmOptions;
+
+  let originalWidth;
+  let originalHeight;
+
+  const identify = childProcess.spawnSync(appPath, ['identify', tempOriginal], { encoding: 'utf-8' });
+  if (!identify.stderr) {
+    // Example output:
+    // /tmp/screen_shot_2021_02_01_at_09.png PNG 642x664 642x664+0+0 8-bit sRGB 666819B 0.000u 0:00.000
+    const identifyStdout = identify.stdout;
+    const identifyData = identifyStdout.split(' ');
+    const [imageWidth, imageHeight] = identifyData[2].split('x');
+    originalWidth = parseInt(imageWidth, 10);
+    originalHeight = parseInt(imageHeight, 10);
+  }
+
   // resize each image =>
   console.log('rules ', rules);
-  const resizeImages = await resize(rules, imageVehicle, storageKey, uuid, imageName, tempOriginal, appPath);
+  const resizeImages = await resize(rules, imageVehicle, storageKey, uuid, imageName, tempOriginal, appPath, originalWidth);
   const { error: newErr, converted } = await format(resizeImages);
   const types = await converted;
 
@@ -44,17 +59,11 @@ exports.default = async (event, gmOptions, env) => {
     uri: `${storageKey}/${uuid}/`
   };
 
-  const identify = childProcess.spawnSync(appPath, ['identify', tempOriginal], { encoding: 'utf-8' });
-  if (!identify.stderr) {
-    // Example output:
-    // /tmp/screen_shot_2021_02_01_at_09.png PNG 642x664 642x664+0+0 8-bit sRGB 666819B 0.000u 0:00.000
-    const identifyStdout = identify.stdout;
-    const identifyData = identifyStdout.split(' ');
-    const [imageWidth, imageHeight] = identifyData[2].split('x');
+  if (originalWidth && originalHeight) {
     response.dimensions = {
-      originalHeight: parseInt(imageHeight, 10),
-      originalWidth: parseInt(imageWidth, 10),
-      aspectRatio: parseFloat((imageWidth / imageHeight).toFixed(2))
+      originalHeight,
+      originalWidth,
+      aspectRatio: parseFloat((originalWidth / originalHeight).toFixed(2))
     };
   }
 

--- a/lambda/resize.js
+++ b/lambda/resize.js
@@ -5,19 +5,20 @@ const util = require('util');
 
 const readFile = util.promisify(fs.readFile);
 
-exports.default = async (rules, imageVehicle, storageKey, uuid, imageName, tempOriginal, appPath) => {
+exports.default = async (rules, imageVehicle, storageKey, uuid, imageName, tempOriginal, appPath, originalWidth) => {
   let err = null;
   let tmpResizedDescriptor;
   let resizedImage;
   let returnedImage;
   const resizedImages = Object.entries(rules).map(async ([imageMod, imageDim]) => {
+    const width = (originalWidth && originalWidth < imageDim.width) ? originalWidth : imageDim.width;
     const magickArgs = [
       '-filter',
       'Triangle',
       '-define',
       'filter:support=2',
       '-thumbnail',
-      `${imageDim.width}`,
+      `${width}`,
       '-unsharp',
       '0.25x0.25+8+0.065',
       '-dither',
@@ -44,7 +45,7 @@ exports.default = async (rules, imageVehicle, storageKey, uuid, imageName, tempO
     ];
     const magickGifArgs = [
       '-resize',
-      `${imageDim.width}`,
+      `${width}`,
       '+dither',
       '-layers',
       'optimize',

--- a/lambda/resize.js
+++ b/lambda/resize.js
@@ -43,11 +43,15 @@ exports.default = async (rules, imageVehicle, storageKey, uuid, imageName, tempO
       '-strip'
     ];
     const magickGifArgs = [
+      '-resize',
+      `${imageDim.width}`,
       '+dither',
       '-layers',
-      'Optimize',
+      'optimize',
       '-colors',
-      '32'
+      '32',
+      '-fuzz',
+      '10%'
     ];
     try {
       tmpResizedDescriptor = await imageVehicle.dir('tmp', imageMod);


### PR DESCRIPTION
This PR:
- optimizes GIF compression while maintaining quality
- converts GIF in different sizes (before we used the original dimensions for all sizes)
- disallows upscaling of an asset (resize can be lower or equal to original width, never greater)

|Before (4MB @ 2160x1000, all sizes the same)|After (2.9MB @ 2160x1000, large retina, other sizes much smaller)|
|---|---|
|![Toys_Main_Mobile](https://user-images.githubusercontent.com/31952489/106748368-72285100-6625-11eb-926e-7c9712b1294c.gif)|![toys_main_mobile-large-retina](https://user-images.githubusercontent.com/31952489/106748408-7d7b7c80-6625-11eb-9c0c-7d183214f2be.gif)|