### PR TITLE
[TEC-2567] Gif optimization (2)

### DIFF
--- a/lambda/resize.js
+++ b/lambda/resize.js
@@ -44,15 +44,15 @@ exports.default = async (rules, imageVehicle, storageKey, uuid, imageName, tempO
       '-strip'
     ];
     const magickGifArgs = [
-      '-resize',
-      `${width}`,
       '+dither',
       '-layers',
       'optimize',
       '-colors',
       '32',
       '-fuzz',
-      '10%'
+      '10%',
+      '-resize',
+      `${width}`
     ];
     try {
       tmpResizedDescriptor = await imageVehicle.dir('tmp', imageMod);


### PR DESCRIPTION
This fixes image degradation for GIFs when converted to lower sizes. Looks like options order matters a lot!

|Before|After|
|---|---|
|![toys_main_mobile-medium-retina](https://user-images.githubusercontent.com/31952489/106758419-c3d6d880-6631-11eb-9135-744ed4190686.gif)|![toys_main_mobile-medium-retina (1)](https://user-images.githubusercontent.com/31952489/106758450-cafde680-6631-11eb-8db2-f05b05b3dc46.gif)|