### PR TITLE
[TEC-2955] - progressive jpegs for CMS images

### DIFF
--- a/lambda/format.js
+++ b/lambda/format.js
@@ -27,7 +27,7 @@ exports.default = async (params) => {
       let returnedImage;
       if (conversionFormat.extension !== extension) {
         const resizedReformatted = `${originalResized.split('.')[0]}.${conversionFormat.extension}`;
-        const reformatProcess = childProcess.spawnSync(appPath, [originalResized, resizedReformatted]);
+        const reformatProcess = childProcess.spawnSync(appPath, [originalResized, '-interlace', 'plane', resizedReformatted]);
         try {
           reformatedImage = await readFile(resizedReformatted).then(data => data);
         } catch (e) {

--- a/lambda/resize.js
+++ b/lambda/resize.js
@@ -38,7 +38,7 @@ exports.default = async (rules, imageVehicle, storageKey, uuid, imageName, tempO
       '-define',
       'png:exclude-chunk=all',
       '-interlace',
-      'none',
+      'plane',
       '-colorspace',
       'sRGB',
       '-strip'


### PR DESCRIPTION
This updates the `-interlace` value in `magickArgs` in `resize.js` to `plane` to create progressive jpegs from jpegs uploaded via the CMS.

Also adds the same value into `reformatProcess` inside of `format.js` since changing the extension via imagemagick sets the `-interlace` value to `none` otherwise.


Tested on QA

uploading this:
![banner-original](https://user-images.githubusercontent.com/47193931/106805514-c8e95700-6634-11eb-80e0-70d1a2b0ae76.jpg)


results in:
![banner_original-large](https://user-images.githubusercontent.com/47193931/106805526-cd157480-6634-11eb-8b0e-3da2db626d15.jpg)

resource for testing: https://www.imgonline.com.ua/eng/progressive-or-baseline-jpeg.php