### PR TITLE
TEC-2991 - add and properly install xml delegate to process certain images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,11 @@ RUN yum clean all
 
 # Download image dependencies
 RUN wget https://www.imagemagick.org/download/delegates/openjpeg-2.3.0.tar.gz
+RUN wget https://www.imagemagick.org/download/delegates/libxml2-2.9.6.tar.gz
 RUN wget https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-7.0.10-35.tar.xz
 
 RUN tar -xzvf openjpeg-*.tar.gz
+RUN tar -xzvf libxml2-*.tar.gz
 RUN tar -xvf ImageMagick-7.0.10-35.tar.xz
 
 RUN cd openjpeg-* \
@@ -44,6 +46,12 @@ RUN cd openjpeg-* \
     && make \
     && make install \
     && cp libopenjp2.pc /usr/share/pkgconfig/
+
+RUN cd libxml2-* \
+    && ./configure \
+    && make \
+    && make install \
+    && cp libxml-2.0.pc /usr/share/pkgconfig/
 
 RUN cd ImageMagick-* \
     && ./configure \
@@ -59,6 +67,7 @@ RUN /usr/local/bin/magick -list format | grep -i "^[[:space:]]*webp"
 
 # Remove tar files
 RUN rm openjpeg-*.tar.gz
+RUN rm libxml2-*.tar.gz
 RUN rm ImageMagick-*.tar.xz
 
 # pip installation


### PR DESCRIPTION
It looks like we just needed to properly install a delegate for imageMagick that we ran into a while back. Still going to do more QA here, but it has been successful so far.

Not sure why it was needed, but this allows images to be uploaded that were previously not being uploaded.

Tested in a different PR by wrapping the magick child process in a try catch to log out the errors we were having on those certain images. The error was complaining about this missing delegate.